### PR TITLE
Update test output with coverage and add hhvm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,16 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - hhvm
+  - hhvm-nightly
+
+matrix:
+  allow_failures:
+    - php: hhvm
+    - php: hhvm-nightly
 
 install:
   - composer --dev --prefer-source --no-interaction install
+
+script:
+  - phpunit --coverage-text

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,4 +4,9 @@
             <directory>test/</directory>
         </testsuite>
     </testsuites>
+    <filter>
+      <blacklist>
+         <directory>./vendor</directory>
+      </blacklist>
+   </filter>
 </phpunit>


### PR DESCRIPTION
I saw you pulled hhvm from tests in a recent commit. Adding this PR will allow hhvm tests to fail and still report build success so long as the PHP tests pass.

I also blacklisted the vendor directory, and added text coverage to the PHPUnit output so you can see where more tests are needed.
