### PR TITLE
able to use symfony3.0 without breaking bc

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,14 +14,14 @@
     },
     "require": {
         "react/react": "~0.4",
-        "symfony/console": "2.6 - 3.0",
-        "symfony/expression-language": "2.6 - 3.0",
-        "symfony/debug": "2.6 - 3.0"
+        "symfony/console": "~2.6|~3.0",
+        "symfony/expression-language": "~2.6|~3.0",
+        "symfony/debug": "~2.6|~3.0"
     },
     "require-dev": {
-        "symfony/finder": "2.6 - 3.0",
+        "symfony/finder": "~2.6|~3.0",
         "phpunit/phpunit": "~4.4",
-        "symfony/process": "2.6 - 3.0"
+        "symfony/process": "~2.6|~3.0"
     },
     "bin": ["pure"],
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -14,14 +14,14 @@
     },
     "require": {
         "react/react": "~0.4",
-        "symfony/console": "~2.6",
-        "symfony/expression-language": "~2.6",
-        "symfony/debug": "~2.6"
+        "symfony/console": "2.6 - 3.0",
+        "symfony/expression-language": "2.6 - 3.0",
+        "symfony/debug": "2.6 - 3.0"
     },
     "require-dev": {
-        "symfony/finder": "~2.6",
+        "symfony/finder": "2.6 - 3.0",
         "phpunit/phpunit": "~4.4",
-        "symfony/process": "~2.6"
+        "symfony/process": "2.6 - 3.0"
     },
     "bin": ["pure"],
     "license": "MIT",

--- a/pure
+++ b/pure
@@ -2,7 +2,7 @@
 <?php
 require __DIR__ . '/vendor/autoload.php';
 
-Symfony\Component\Debug\ErrorHandler::register(false);
+Symfony\Component\Debug\ErrorHandler::register();
 
 $console = new Symfony\Component\Console\Application('PurePHP', '1.1.0');
 $console->add(new Pure\Console\StartCommand());

--- a/pure
+++ b/pure
@@ -4,7 +4,7 @@ require __DIR__ . '/vendor/autoload.php';
 
 Symfony\Component\Debug\ErrorHandler::register();
 
-$console = new Symfony\Component\Console\Application('PurePHP', '1.1.0');
+$console = new Symfony\Component\Console\Application('PurePHP', '1.2.0');
 $console->add(new Pure\Console\StartCommand());
 $console->add(new Pure\Console\ClientCommand());
 $console->run();


### PR DESCRIPTION
When upgrading i checked for deprecated features but couldn't find any. I also used https://github.com/sensiolabs-de/deprecation-detector to double check.

If this gets merged, i'm guessing that https://github.com/deployphp/deployer can also update their dependencies and we can all start using symfony3.0, or am i overlooking something here..?
